### PR TITLE
tweaked the text in this README file because I'm still not quite sure…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,3 +11,5 @@ I've run each and all of these programs with the Anaconda’s Python distributio
 
 
 == Usage
+
+When run from the command line, fibonacci-sequence-generator.py prompts the user to enter an integer value. Returns at the command line The Fibonacci sequence up to the user-supplied value.


### PR DESCRIPTION
… about certain features in GitHub's flavor of AsciiDoc.

- Attempted to use the monospaced font for the first python program's filename in the README.
- fixed some verbiage in the earlier section. 